### PR TITLE
Fix name alias handling in openqa-devel-setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ user. The openQA packages are only installed to pull runtime dependencies.
   created via the web UI.
 * `mkdir -p $OPENQA_BASEDIR/repos; cd $OPENQA_BASEDIR/repos; git checkout https://github.com/Martchus/openQA-helper.git`
 * Install all packages required for openQA development via `openqa-install-devel-deps`.
-* Fork all required repos on GitHub. For the list of repos, just checkout the
-  `openqa-devel-setup` script.
+* Fork all required repos on GitHub under your name: `os-autoinst/os-autoinst`, `os-autoinst/openQA`,
+  `os-autoinst/os-autoinst-distri-opensuse` and `os-autoinst/os-autoinst-needles-opensuse`.
 * Execute `openqa-devel-setup your_github_name` to clone all required repos. This also adds your
   forks.
 

--- a/scripts/openqa-devel-setup
+++ b/scripts/openqa-devel-setup
@@ -26,8 +26,8 @@ function clone_repo() {
         return 0
     fi
     
-    git clone "$repo_url" "$repo_name" "$repo_as"
-    pushd "$repo_name"
+    git clone "$repo_url" "$repo_as"
+    pushd "$repo_as"
     git remote add "$gh_user" "git@github.com:$gh_user/$repo_name.git"
     git remote update
     popd
@@ -36,7 +36,7 @@ function clone_repo() {
 # clone openQA and create required directories for config and test data
 clone_repo openQA
 mkdir -p "$OPENQA_BASEDIR/config"
-cp "$OPENQA_BASEDIR/repos/etc/"* "$OPENQA_BASEDIR/config"
+cp -r "$OPENQA_BASEDIR/repos/openQA/etc/"* "$OPENQA_BASEDIR/config"
 mkdir -p "$OPENQA_BASEDIR/openqa/"{db,testresults,share}
 mkdir -p "$OPENQA_BASEDIR/openqa/share/factory/"{iso,other}
 


### PR DESCRIPTION
I was having some trouble with setting up the required directory structure with `openqa-devel-setup`. These changes made everything work for me. Having the four required repos listed in the README also seems like a good idea.