### PR TITLE
Check repo_as when skipping cloned folder

### DIFF
--- a/lib/clone_repo.sh
+++ b/lib/clone_repo.sh
@@ -6,7 +6,7 @@ function clone_repo() {
     local repo_as=${2:-$repo_name}
     local repo_url="https://github.com/os-autoinst/$repo_name"
 
-    if [[ -d $repo_name ]]; then
+    if [[ -d $repo_as ]]; then
         echo "Skipping $repo_name; already exists."
         return 0
     fi

--- a/scripts/openqa-devel-setup
+++ b/scripts/openqa-devel-setup
@@ -36,7 +36,6 @@ mkdir -p "$OPENQA_BASEDIR/openqa/share/tests"
 cd "$OPENQA_BASEDIR/openqa/share/tests"
 clone_repo os-autoinst-distri-opensuse opensuse
 ln -s opensuse sle
-clone_repo os-autoinst-distri-opensuse opensuse
 
 # create symlinks for tidy
 cd "$OPENQA_BASEDIR/openqa/share/tests/opensuse"


### PR DESCRIPTION
When skipping existing clones `$repo_as` is the relevant folder name to check.