### PR TITLE
 Prove command add -l parameter after OpenQA removed lib from @NIC in tests

### DIFF
--- a/scripts/openqa-test
+++ b/scripts/openqa-test
@@ -17,5 +17,5 @@ export OPENQA_BASEDIR="$basedir"
 export OPENQA_CONFIG=
 export MOJO_PORT="${MOJO_PORT:-12345}"
 
-echo prove -v "$@"
-prove -v "$@"
+echo prove -l -v "$@"
+prove -l -v "$@"


### PR DESCRIPTION
In openqa-test script, change `prove -v` to `prove -l -v`