### PR TITLE
Enhance environmental variable handling

### DIFF
--- a/scripts/openqa-start
+++ b/scripts/openqa-start
@@ -1,12 +1,13 @@
 #!/bin/bash
 set -e
-export OPENQA_CODEBASE=$OPENQA_BASEDIR/repos/openQA # used to get POD from controllers
+export OPENQA_CODEBASE=${OPENQA_CODEBASE:-$OPENQA_BASEDIR/repos/openQA} # used to get POD from controllers
 export LANGUAGE= LANG=C.utf8
 cd "$OPENQA_CODEBASE"
 what=$1
 shift || true
 
-source "$OPENQA_BASEDIR/repos/openQA-helper/lib/customize_dirs.sh"
+OPENQA_HELPER_DIR=${OPENQA_HELPER_DIR:-$OPENQA_BASEDIR/repos/openQA-helper}
+source "$OPENQA_HELPER_DIR/lib/customize_dirs.sh"
 
 declare -A shortcuts=(
     [wu]=webui


### PR DESCRIPTION
## Description

Since I'm not using a conventional repository path, I think generalize those two environmental variable could help

## Example

For this I've enabled bash debugging `xtrace`:

```
$ OPENQA_CODEBASE=~/Workspaces/Github-Suse/os-autoinst/openQA/wt1 OPENQA_HELPER_DIR=~/Workspaces/Github-Suse/martchus/openQA-helper/wt1 ./scripts/openqa-start wu
+ set -e
+ export OPENQA_CODEBASE=/home/wabri/Workspaces/Github-Suse/os-autoinst/openQA/wt1
+ OPENQA_CODEBASE=/home/wabri/Workspaces/Github-Suse/os-autoinst/openQA/wt1
+ export LANGUAGE= LANG=C.utf8
+ LANGUAGE=
+ LANG=C.utf8
+ cd /home/wabri/Workspaces/Github-Suse/os-autoinst/openQA/wt1
```